### PR TITLE
Add pricing section with smooth scroll

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -13,7 +13,7 @@ export default function Navbar() {
             <a href="#how-it-works" className="text-gray-600 hover:text-gray-900">
               How It Works
             </a>
-            <a href="#" className="text-gray-600 hover:text-gray-900">Pricing</a>
+            <a href="#pricing" className="text-gray-600 hover:text-gray-900">Pricing</a>
             <a href="#" className="text-gray-600 hover:text-gray-900">FAQ</a>
           </div>
           <div className="flex gap-3">

--- a/pages/index.js
+++ b/pages/index.js
@@ -136,6 +136,79 @@ export default function Home() {
       </section>
       </div>
 
+      {/* Pricing Section */}
+      <section id="pricing" className="py-20 px-4 bg-white">
+        <div className="max-w-6xl mx-auto text-center">
+          <h2 className="text-3xl sm:text-4xl font-bold text-gray-900">
+            Simple, Transparent Pricing
+          </h2>
+          <p className="mt-2 text-gray-600 mb-12">
+            Choose the plan that works best for your project needs
+          </p>
+          <div className="grid gap-8 md:grid-cols-3">
+            {/* Basic */}
+            <div className="bg-white rounded-lg shadow p-6 flex flex-col">
+              <h3 className="text-lg font-semibold text-purple-600 mb-2">Basic</h3>
+              <p className="text-4xl font-extrabold text-purple-600 mb-2">$499</p>
+              <p className="mb-4 text-gray-600">Perfect for simple apps and MVPs</p>
+              <ul className="text-gray-600 flex-1 space-y-2 mb-6 text-left">
+                <li>5 AI-generated templates</li>
+                <li>Basic customization</li>
+                <li>30 days support</li>
+                <li>Export to Flutter</li>
+              </ul>
+              <a
+                href="#"
+                className="mt-auto px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-700"
+              >
+                Get Started
+              </a>
+            </div>
+
+            {/* Professional */}
+            <div className="bg-white rounded-lg shadow p-6 flex flex-col border-2 border-purple-600 relative">
+              <span className="absolute -top-3 left-1/2 -translate-x-1/2 bg-purple-600 text-white text-xs font-semibold px-2 py-1 rounded-full">
+                Most Popular
+              </span>
+              <h3 className="mt-3 text-lg font-semibold text-purple-600 mb-2">Professional</h3>
+              <p className="text-4xl font-extrabold text-purple-600 mb-2">$1,499</p>
+              <p className="mb-4 text-gray-600">For businesses with specific requirements</p>
+              <ul className="text-gray-600 flex-1 space-y-2 mb-6 text-left">
+                <li>15 templates</li>
+                <li>Advanced customization</li>
+                <li>90 days support</li>
+                <li>Developer assistance (10h)</li>
+              </ul>
+              <a
+                href="#"
+                className="mt-auto px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-700"
+              >
+                Get Started
+              </a>
+            </div>
+
+            {/* Enterprise */}
+            <div className="bg-white rounded-lg shadow p-6 flex flex-col">
+              <h3 className="text-lg font-semibold text-purple-600 mb-2">Enterprise</h3>
+              <p className="text-4xl font-extrabold text-purple-600 mb-2">Custom</p>
+              <p className="mb-4 text-gray-600">For large-scale and complex applications</p>
+              <ul className="text-gray-600 flex-1 space-y-2 mb-6 text-left">
+                <li>Unlimited templates</li>
+                <li>Full customization</li>
+                <li>1-year support</li>
+                <li>Dedicated dev team</li>
+              </ul>
+              <a
+                href="#"
+                className="mt-auto px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-700"
+              >
+                Contact Us
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
       </>
   );
 }


### PR DESCRIPTION
## Summary
- add pricing card section below How It Works
- link navbar item to new pricing section
- ensure smooth scrolling remains enabled

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846ee68542c832f9248fedab2bfb8f6