### PR TITLE
Revamp landing page styling

### DIFF
--- a/components/FAQ.js
+++ b/components/FAQ.js
@@ -32,33 +32,43 @@ export default function FAQ() {
 
   return (
     <section id="faq" className="py-20 px-4 bg-white scroll-mt-20">
-      <h2 className="text-3xl sm:text-4xl font-bold text-center mb-10">
-        Frequently Asked Questions
-      </h2>
+      <h2 className="text-3xl font-bold text-center mb-10">Frequently Asked Questions</h2>
       <div className="max-w-3xl mx-auto space-y-4">
         {faqs.map((faq, index) => (
           <div
             key={index}
-            className="bg-white rounded-lg shadow-md p-5 transition hover:shadow-lg"
+            className="bg-white rounded-lg shadow p-4 space-y-2 transition hover:shadow-lg"
           >
             <div
               onClick={() => toggle(index)}
               className="flex justify-between cursor-pointer font-semibold text-lg"
             >
               <span>{faq.question}</span>
-              <span
-                className={`transform transition-transform duration-300 ${
-                  openIndex === index ? 'rotate-45' : ''
-                }`}
-              >
-                +
-              </span>
+              {openIndex === index ? (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-5 h-5 stroke-[2]"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M18 12H6" />
+                </svg>
+              ) : (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-5 h-5 stroke-[2]"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m6-6H6" />
+                </svg>
+              )}
             </div>
             <div
-              className={`mt-3 transition-all duration-300 ease-in-out overflow-hidden ${
-                openIndex === index
-                  ? 'opacity-100 max-h-screen'
-                  : 'opacity-0 max-h-0'
+              className={`transition-all duration-300 ease-in overflow-hidden ${
+                openIndex === index ? 'opacity-100 max-h-screen' : 'opacity-0 max-h-0'
               }`}
             >
               <p className="text-gray-600">{faq.answer}</p>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function Footer() {
   return (
-    <footer className="bg-gray-900 text-gray-400 py-10 px-6 md:px-16 lg:px-24">
+    <footer className="bg-gray-900 text-gray-400 px-6 md:px-20 py-12">
       <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-4 gap-8">
         <div>
           <h3 className="text-white font-bold text-xl mb-2">FlutterPup</h3>
@@ -35,10 +35,10 @@ export default function Footer() {
           </ul>
         </div>
       </div>
-      <div className="max-w-6xl mx-auto mt-8 border-t border-gray-700 pt-6 flex flex-col md:flex-row items-center justify-between">
+      <div className="max-w-6xl mx-auto mt-12 border-t border-gray-800 pt-6 flex justify-between items-center">
         <p className="text-sm">&copy; 2023 FlutterPup. All rights reserved.</p>
-        <div className="flex gap-4 mt-4 md:mt-0">
-          <a href="https://facebook.com/flutterpup" className="hover:text-white" aria-label="Facebook">
+        <div className="flex gap-4">
+          <a href="https://facebook.com/flutterpup" target="_blank" rel="noopener noreferrer" className="w-5 h-5 text-gray-400 hover:text-white transition" aria-label="Facebook">
             <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path d="M18 2h-3a5 5 0 00-5 5v3H8v4h2v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z"/>
             </svg>
@@ -47,14 +47,14 @@ export default function Footer() {
             href="https://instagram.com/flutterpup"
             target="_blank"
             rel="noopener noreferrer"
-            className="hover:text-white"
+            className="w-5 h-5 text-gray-400 hover:text-white transition"
             aria-label="Instagram"
           >
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" className="w-5 h-5">
               <path d="M7.75 2C4.6 2 2 4.6 2 7.75v8.5C2 19.4 4.6 22 7.75 22h8.5c3.15 0 5.75-2.6 5.75-5.75v-8.5C22 4.6 19.4 2 16.25 2h-8.5zm0 1.5h8.5A4.26 4.26 0 0120.5 7.75v8.5a4.26 4.26 0 01-4.25 4.25h-8.5A4.26 4.26 0 013.5 16.25v-8.5A4.26 4.26 0 017.75 3.5zM12 7a5 5 0 100 10 5 5 0 000-10zm0 1.5a3.5 3.5 0 110 7 3.5 3.5 0 010-7zm5.25-.88a.88.88 0 100 1.75.88.88 0 000-1.75z" />
             </svg>
           </a>
-          <a href="https://linkedin.com/company/flutterpup" className="hover:text-white" aria-label="LinkedIn">
+          <a href="https://linkedin.com/company/flutterpup" target="_blank" rel="noopener noreferrer" className="w-5 h-5 text-gray-400 hover:text-white transition" aria-label="LinkedIn">
             <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path d="M16 8a6 6 0 016 6v7h-4v-7a2 2 0 00-4 0v7h-4v-7a6 6 0 016-6z" />
               <rect x="2" y="9" width="4" height="12" />

--- a/pages/index.js
+++ b/pages/index.js
@@ -34,26 +34,29 @@ export default function Home() {
         <title>FlutterPup</title>
       </Head>
       <Navbar />
-      <div className="flex items-center justify-center min-h-screen p-6 bg-gradient-to-br from-purple-50 to-purple-200">
-        <section className="max-w-6xl w-full flex flex-col md:flex-row items-center justify-between gap-12">
-          <div className="flex-1 text-center md:text-left">
-          <span className="inline-block text-xs font-semibold bg-purple-100 text-purple-800 px-3 py-1 rounded-full">
+      <div className="flex items-center justify-center min-h-screen p-6 bg-gradient-to-r from-purple-500 to-indigo-500">
+        <section className="max-w-6xl w-full flex flex-col md:flex-row items-center justify-between gap-12 py-12">
+          <div className="flex-1 text-center md:text-left text-white">
+          <span className="inline-block text-xs font-semibold bg-white/20 text-white px-3 py-1 rounded-full">
             AI-Powered Flutter Development
           </span>
-          <h1 className="mt-4 text-4xl sm:text-5xl font-extrabold text-gray-900">
+          <h1 className="mt-4 text-4xl sm:text-5xl font-extrabold">
             Launch Your App with AI-Powered Flutter Templates
           </h1>
-          <p className="mt-4 text-lg text-gray-600 max-w-xl mx-auto md:mx-0">
+          <p className="mt-4 text-lg max-w-xl mx-auto md:mx-0">
             Build production-ready Flutter apps faster using our AI-driven templates and tools. Focus on your idea while we handle the scaffolding.
           </p>
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center md:justify-start gap-4">
             <a
               href="#"
-              className="px-8 py-3 bg-purple-600 text-white rounded-lg shadow hover:bg-purple-700 transition font-semibold"
+              className="px-6 py-2 text-sm font-semibold rounded-lg bg-white text-purple-700 hover:bg-purple-50"
             >
               Start with your idea
             </a>
-            <a href="#how-it-works" className="text-purple-700 font-semibold hover:underline">
+            <a
+              href="#how-it-works"
+              className="px-6 py-2 text-sm font-semibold rounded-lg border border-white text-white hover:bg-white/10"
+            >
               See how it works
             </a>
           </div>
@@ -105,33 +108,21 @@ export default function Home() {
           <h2 className="text-3xl sm:text-4xl font-bold text-center text-gray-900 mb-12">
             How It Works
           </h2>
-          <div className="grid gap-6 md:grid-cols-3">
-            <div className="p-6 bg-white rounded-lg shadow-md flex flex-col items-center justify-center text-center aspect-square">
-              <div className="text-5xl mb-4 text-purple-600">🤖</div>
-              <h3 className="text-lg font-semibold text-purple-600 mb-2">
-                AI-Powered Template Selection
-              </h3>
-              <p className="text-gray-600">
-                Our AI analyzes your requirements and suggests the perfect Flutter templates to kickstart your project...
-              </p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="bg-white shadow-md p-6 rounded-xl aspect-square h-72 flex flex-col justify-center items-center">
+              <div className="text-purple-500 w-8 h-8 mb-4 text-3xl">🤖</div>
+              <h3 className="font-bold text-lg text-center mb-2">AI-Powered Template Selection</h3>
+              <p className="text-center text-gray-600">Our AI analyzes your requirements and suggests the perfect Flutter templates to kickstart your project...</p>
             </div>
-            <div className="p-6 bg-white rounded-lg shadow-md flex flex-col items-center justify-center text-center aspect-square">
-              <div className="text-5xl mb-4 text-purple-600">🎨</div>
-              <h3 className="text-lg font-semibold text-purple-600 mb-2">
-                Customization Made Easy
-              </h3>
-              <p className="text-gray-600">
-                Easily customize your Flutter app with our intuitive interface...
-              </p>
+            <div className="bg-white shadow-md p-6 rounded-xl aspect-square h-72 flex flex-col justify-center items-center">
+              <div className="text-purple-500 w-8 h-8 mb-4 text-3xl">🎨</div>
+              <h3 className="font-bold text-lg text-center mb-2">Customization Made Easy</h3>
+              <p className="text-center text-gray-600">Easily customize your Flutter app with our intuitive interface...</p>
             </div>
-            <div className="p-6 bg-white rounded-lg shadow-md flex flex-col items-center justify-center text-center aspect-square">
-              <div className="text-5xl mb-4 text-purple-600">👥</div>
-              <h3 className="text-lg font-semibold text-purple-600 mb-2">
-                Expert Flutter Developers
-              </h3>
-              <p className="text-gray-600">
-                Connect with our network of vetted Flutter developers...
-              </p>
+            <div className="bg-white shadow-md p-6 rounded-xl aspect-square h-72 flex flex-col justify-center items-center">
+              <div className="text-purple-500 w-8 h-8 mb-4 text-3xl">👥</div>
+              <h3 className="font-bold text-lg text-center mb-2">Expert Flutter Developers</h3>
+              <p className="text-center text-gray-600">Connect with our network of vetted Flutter developers...</p>
             </div>
           </div>
         </div>
@@ -141,13 +132,9 @@ export default function Home() {
       {/* Pricing Section */}
       <section id="pricing" className="py-20 px-4 bg-white">
         <div className="max-w-6xl mx-auto text-center">
-          <h2 className="text-3xl sm:text-4xl font-bold text-gray-900">
-            Simple, Transparent Pricing
-          </h2>
-          <p className="mt-2 text-gray-600 mb-12">
-            Choose the plan that works best for your project needs
-          </p>
-          <div className="grid gap-8 md:grid-cols-3">
+          <h2 className="text-center text-3xl font-bold mb-4">Simple, Transparent Pricing</h2>
+          <p className="text-gray-600 mb-12">Choose the plan that works best for your project needs</p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {/* Basic */}
             <div className="bg-white rounded-lg shadow p-6 flex flex-col">
               <h3 className="text-lg font-semibold text-purple-600 mb-2">Basic</h3>
@@ -161,14 +148,14 @@ export default function Home() {
               </ul>
               <a
                 href="#"
-                className="mt-auto px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-700"
+                className="mt-auto px-6 py-2 text-sm font-semibold rounded-lg bg-purple-600 text-white hover:bg-purple-700"
               >
                 Get Started
               </a>
             </div>
 
             {/* Professional */}
-            <div className="bg-white rounded-lg shadow p-6 flex flex-col border-2 border-purple-600 relative">
+            <div className="bg-white rounded-lg shadow p-6 flex flex-col ring-2 ring-purple-500 relative">
               <span className="absolute -top-3 left-1/2 -translate-x-1/2 bg-purple-600 text-white text-xs font-semibold px-2 py-1 rounded-full">
                 Most Popular
               </span>
@@ -183,7 +170,7 @@ export default function Home() {
               </ul>
               <a
                 href="#"
-                className="mt-auto px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-700"
+                className="mt-auto px-6 py-2 text-sm font-semibold rounded-lg bg-purple-600 text-white hover:bg-purple-700"
               >
                 Get Started
               </a>
@@ -202,7 +189,7 @@ export default function Home() {
               </ul>
               <a
                 href="#"
-                className="mt-auto px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-700"
+                className="mt-auto px-6 py-2 text-sm font-semibold rounded-lg bg-purple-600 text-white hover:bg-purple-700"
               >
                 Contact Us
               </a>


### PR DESCRIPTION
## Summary
- add purple hero gradient and styled CTA buttons
- square "How it works" cards
- update pricing layout and highlight Professional plan
- modernize FAQ toggle cards with plus/minus icons
- polish footer spacing and icon styles

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470158e118832f9d604a20b69f4428