### PR TITLE
UI tweaks for navbar and hero

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -9,22 +9,22 @@ export default function Navbar() {
           <span className="text-2xl">FlutterPup</span>
         </div>
         <div className="flex items-center gap-6">
-          <a href="#how-it-works" className="text-gray-700 hover:text-purple-600">
+          <a href="#how-it-works" className="text-gray-700 hover:text-purple-600 font-semibold">
             How It Works
           </a>
-          <a href="#pricing" className="text-gray-700 hover:text-purple-600">
+          <a href="#pricing" className="text-gray-700 hover:text-purple-600 font-semibold">
             Pricing
           </a>
-          <a href="#faq" className="text-gray-700 hover:text-purple-600">
+          <a href="#faq" className="text-gray-700 hover:text-purple-600 font-semibold">
             FAQ
           </a>
           <a
             href="#"
-            className="border border-[#6466f1] text-[#6466f1] rounded-full px-4 py-2 text-sm font-bold hover:bg-purple-100"
+            className="border border-[#6466f1] text-[#6466f1] rounded-md px-3 py-1 text-sm font-bold hover:bg-purple-100"
           >
             Login
           </a>
-          <button className="bg-[#6466f1] text-white rounded-full px-4 py-2 hover:bg-purple-700 text-sm ml-2 font-bold">
+          <button className="bg-[#6466f1] text-white rounded-md px-3 py-1 hover:bg-purple-700 text-sm ml-1 font-bold">
             Get Started
           </button>
         </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -35,10 +35,10 @@ export default function Home() {
       </Head>
       <Navbar />
       <main className="scroll-smooth">
-        <section className="min-h-screen flex items-center px-4 bg-gradient-to-br from-[#6666f2] to-[#885df5]">
+        <section className="min-h-screen flex items-start pt-8 pb-6 px-0 bg-gradient-to-br from-[#6666f2] to-[#885df5]">
           <div className="flex flex-col md:flex-row justify-start items-start max-w-7xl mx-auto gap-12">
             <div className="text-white space-y-4 text-center md:text-left flex-1">
-              <span className="inline-flex items-center text-xs font-semibold text-white bg-gradient-to-r from-[#6666f2]/80 to-[#885df5]/80 px-4 py-1 rounded-full w-max">
+              <span className="inline-flex items-center text-xs font-semibold text-white bg-gradient-to-r from-[#8584f4] to-[#8f82f6] px-4 py-1 rounded-lg w-full">
                 <span className="mr-2 text-sm">☆</span>
                 AI-Powered Flutter Development
               </span>
@@ -52,13 +52,13 @@ export default function Home() {
               <div className="flex flex-col md:flex-row gap-4 mt-6">
                 <a
                   href="#"
-                  className="px-12 py-4 text-sm font-semibold rounded-lg bg-white text-[#6466f2] hover:bg-purple-50"
+                  className="px-12 py-4 text-base font-bold rounded-lg bg-white text-[#6466f2] hover:bg-purple-50"
                 >
                   Start with your idea<span className="ml-2">→</span>
                 </a>
                 <a
                   href="#how-it-works"
-                  className="px-8 py-2 text-sm font-semibold text-white rounded-lg hover:bg-white/10"
+                  className="px-8 py-2 text-base font-bold text-white rounded-lg hover:bg-white/10"
                 >
                   See how it works
                 </a>
@@ -72,9 +72,7 @@ export default function Home() {
                 height={200}
                 className="w-full h-full object-cover"
               />
-              <span className="w-3 h-3 bg-[#6a60ea] absolute -bottom-2 left-1" />
-              <span className="w-3 h-3 bg-[#6a60ea] absolute -bottom-2 left-5" />
-              <span className="w-3 h-3 bg-[#6a60ea] absolute -bottom-2 left-9" />
+              <div className="absolute bottom-[-40px] right-[25%] w-[250px] h-[180px] bg-[#8054FF]/30 rounded-[60px] blur-2xl z-[-1]" />
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- refine login and get started buttons in the navbar
- bold navbar links
- tighten hero spacing and style
- enlarge hero badge and add gradient background
- tweak hero call‑to‑action buttons and remove decoration dots
- add soft glow shape behind hero image

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847cab58aa4832f9adfb41fcf2bf60b