### PR TITLE
Remove trailing spaces from index paragraph

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -48,7 +48,7 @@ export default function Home() {
                 <span className="block">Flutter Templates</span>
               </h1>
               <p className="text-lg max-w-xl mx-auto md:mx-0">
-                Transform your business idea into a fully functional Flutter app with our AI-powered template recommendations, customization tools, and developer network.              </p>
+                Transform your business idea into a fully functional Flutter app with our AI-powered template recommendations, customization tools, and developer network.</p>
               <div className="flex flex-col md:flex-row gap-4 mt-6">
                 <a
                   href="#"


### PR DESCRIPTION
## Summary
- tidy whitespace in the hero description paragraph

## Testing
- `grep -n "developer network" -n pages/index.js`

------
https://chatgpt.com/codex/tasks/task_e_6847d3439df8832f97ceb61ada50042a