### PR TITLE
Update icons and adjust footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -3,7 +3,7 @@ import React from 'react';
 export default function Footer() {
   return (
     <footer className="bg-gray-900 text-gray-400 px-6 md:px-20 py-12 border-t border-gray-800">
-      <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-4 gap-8">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
         <div>
           <h3 className="text-white font-bold text-xl mb-2">FlutterPup</h3>
           <p>
@@ -35,12 +35,12 @@ export default function Footer() {
           </ul>
         </div>
       </div>
-      <div className="max-w-6xl mx-auto mt-12 border-t border-gray-800 pt-6 flex justify-between items-center">
+      <div className="mt-12 border-t border-gray-800 pt-6 flex justify-between items-center">
         <p className="text-sm">&copy; 2023 FlutterPup. All rights reserved.</p>
         <div className="flex gap-4">
           <a href="https://facebook.com/flutterpup" target="_blank" rel="noopener noreferrer" className="w-5 h-5 text-gray-400 hover:text-white transition" aria-label="Facebook">
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path d="M18 2h-3a5 5 0 00-5 5v3H8v4h2v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z"/>
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path d="M18 2h-3a5 5 0 00-5 5v3H8v4h2v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
             </svg>
           </a>
           <a
@@ -50,12 +50,14 @@ export default function Footer() {
             className="w-5 h-5 text-gray-400 hover:text-white transition"
             aria-label="Instagram"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" className="w-5 h-5">
-              <path d="M7.75 2C4.6 2 2 4.6 2 7.75v8.5C2 19.4 4.6 22 7.75 22h8.5c3.15 0 5.75-2.6 5.75-5.75v-8.5C22 4.6 19.4 2 16.25 2h-8.5zm0 1.5h8.5A4.26 4.26 0 0120.5 7.75v8.5a4.26 4.26 0 01-4.25 4.25h-8.5A4.26 4.26 0 013.5 16.25v-8.5A4.26 4.26 0 017.75 3.5zM12 7a5 5 0 100 10 5 5 0 000-10zm0 1.5a3.5 3.5 0 110 7 3.5 3.5 0 010-7zm5.25-.88a.88.88 0 100 1.75.88.88 0 000-1.75z" />
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" className="w-5 h-5">
+              <rect x="2" y="2" width="20" height="20" rx="5" />
+              <circle cx="12" cy="12" r="3.5" />
+              <circle cx="17.25" cy="6.88" r="0.88" />
             </svg>
           </a>
           <a href="https://linkedin.com/company/flutterpup" target="_blank" rel="noopener noreferrer" className="w-5 h-5 text-gray-400 hover:text-white transition" aria-label="LinkedIn">
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path d="M16 8a6 6 0 016 6v7h-4v-7a2 2 0 00-4 0v7h-4v-7a6 6 0 016-6z" />
               <rect x="2" y="9" width="4" height="12" />
               <circle cx="4" cy="4" r="2" />

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -5,7 +5,19 @@ export default function Navbar() {
     <nav className="sticky top-0 z-50 bg-white shadow-md px-8 py-4">
       <div className="max-w-6xl mx-auto flex justify-between items-center text-gray-800">
         <div className="flex items-center gap-2 font-bold">
-          <span className="text-2xl">🚀</span>
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l2.062 6.304a1 1 0 00.95.69h6.627c.969 0 1.371 1.24.588 1.81l-5.367 3.898a1 1 0 00-.364 1.118l2.062 6.305c.3.921-.755 1.688-1.538 1.118l-5.367-3.898a1 1 0 00-1.176 0l-5.367 3.898c-.783.57-1.838-.197-1.539-1.118l2.062-6.305a1 1 0 00-.364-1.118L2.391 11.73c-.783-.57-.38-1.81.588-1.81h6.627a1 1 0 00.95-.69l2.062-6.304z"
+            />
+          </svg>
           <span className="text-2xl">FlutterPup</span>
         </div>
         <div className="flex items-center gap-6">

--- a/pages/index.js
+++ b/pages/index.js
@@ -113,17 +113,57 @@ export default function Home() {
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               <div className="bg-white shadow-md p-6 rounded-xl aspect-square h-72 flex flex-col justify-center items-center">
-                <div className="text-purple-500 w-8 h-8 mb-4 text-3xl">🤖</div>
+                <svg
+                  className="text-purple-500 w-8 h-8 mb-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <circle cx="12" cy="12" r="3" />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 2v2m0 16v2m10-10h-2M4 12H2m15.657-7.657l-1.414 1.414M6.757 17.243l-1.414 1.414m12.728 0l-1.414-1.414M6.757 6.757L5.343 5.343"
+                  />
+                </svg>
                 <h3 className="font-bold text-lg text-center mb-2">AI-Powered Template Selection</h3>
                 <p className="text-center text-gray-600">Our AI analyzes your requirements and suggests the perfect Flutter templates to kickstart your project...</p>
               </div>
               <div className="bg-white shadow-md p-6 rounded-xl aspect-square h-72 flex flex-col justify-center items-center">
-                <div className="text-purple-500 w-8 h-8 mb-4 text-3xl">🎨</div>
+                <svg
+                  className="text-purple-500 w-8 h-8 mb-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 3a9 9 0 00-9 9 4 4 0 004 4h1a1 1 0 011 1v1a3 3 0 003 3 9 9 0 009-9 9 9 0 00-9-9z"
+                  />
+                  <circle cx="7" cy="10" r="1" />
+                  <circle cx="15" cy="7" r="1" />
+                  <circle cx="17" cy="12" r="1" />
+                </svg>
                 <h3 className="font-bold text-lg text-center mb-2">Customization Made Easy</h3>
                 <p className="text-center text-gray-600">Easily customize your Flutter app with our intuitive interface...</p>
               </div>
               <div className="bg-white shadow-md p-6 rounded-xl aspect-square h-72 flex flex-col justify-center items-center">
-                <div className="text-purple-500 w-8 h-8 mb-4 text-3xl">👥</div>
+                <svg
+                  className="text-purple-500 w-8 h-8 mb-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M17 20v-2a4 4 0 00-3-3.87M7 20v-2a4 4 0 013-3.87M12 12a4 4 0 100-8 4 4 0 000 8z"
+                  />
+                </svg>
                 <h3 className="font-bold text-lg text-center mb-2">Expert Flutter Developers</h3>
                 <p className="text-center text-gray-600">Connect with our network of vetted Flutter developers...</p>
               </div>
@@ -202,9 +242,7 @@ export default function Home() {
 
         <FAQ />
 
-        <section className="min-h-screen snap-start flex flex-col justify-between items-center px-6 pb-24">
-          <Footer />
-        </section>
+        <Footer />
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- swap emoji rocket for outlined SVG
- replace feature emojis with outline icons
- switch footer social icons to stroke style
- remove fixed width constraints on footer
- place footer directly after FAQ section to remove excess space

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f33afc84832f9c4e7f745d7138c5