### PR TITLE
Fix firebase auth import in password reset modal

### DIFF
--- a/components/ResetPasswordModal.js
+++ b/components/ResetPasswordModal.js
@@ -1,6 +1,6 @@
+'use client';
 import React, { useState } from 'react';
 import { auth } from '../lib/firebaseClient';
-import { sendPasswordResetEmail } from 'firebase/auth';
 
 export default function ResetPasswordModal({ onBack, onClose }) {
   const [email, setEmail] = useState('');
@@ -16,6 +16,7 @@ export default function ResetPasswordModal({ onBack, onClose }) {
     setMessage('');
     if (!email) return;
     try {
+      const { sendPasswordResetEmail } = await import('firebase/auth');
       await sendPasswordResetEmail(auth, email);
       setMessage('Check your email for the reset link.');
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "autoprefixer": "^10.4.14",
     "firebase": "^10.5.0",
-    "next": "^14.0.0",
+    "next": "^14.2.0",
     "postcss": "^8.4.24",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary
- mark ResetPasswordModal as client component and load `sendPasswordResetEmail` dynamically
- update Next.js to 14.2 in package.json

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d704d710c832f81aaf7202efc00ff