### PR TITLE
Fix password reset import for Firebase

### DIFF
--- a/components/ResetPasswordModal.js
+++ b/components/ResetPasswordModal.js
@@ -1,6 +1,7 @@
 'use client';
 import React, { useState } from 'react';
 import { auth } from '../lib/firebaseClient';
+import { sendPasswordResetEmail } from 'firebase/auth';
 
 export default function ResetPasswordModal({ onBack, onClose }) {
   const [email, setEmail] = useState('');
@@ -16,7 +17,6 @@ export default function ResetPasswordModal({ onBack, onClose }) {
     setMessage('');
     if (!email) return;
     try {
-      const { sendPasswordResetEmail } = await import('firebase/auth');
       await sendPasswordResetEmail(auth, email);
       setMessage('Check your email for the reset link.');
     } catch (err) {


### PR DESCRIPTION
## Summary
- statically import `sendPasswordResetEmail` from `firebase/auth`
- remove runtime dynamic import in `ResetPasswordModal`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d7164928c832fb0914db51ba2c8bc