### PR TITLE
Fix duplicate Firebase initialization

### DIFF
--- a/lib/firebaseAnalytics.js
+++ b/lib/firebaseAnalytics.js
@@ -1,6 +1,6 @@
 // Auto-generated Firebase initialization with analytics
 // Import the functions you need from the SDKs you need
-import { initializeApp } from "firebase/app";
+import { initializeApp, getApp, getApps } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
@@ -17,7 +17,7 @@ const firebaseConfig = {
   measurementId: "G-Z0PKF6KX7Z"
 };
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
+// Initialize Firebase if not already initialized
+const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 export const analytics = getAnalytics(app);
 export default app;

--- a/lib/firebaseClient.js
+++ b/lib/firebaseClient.js
@@ -1,4 +1,4 @@
-import { initializeApp } from 'firebase/app';
+import { initializeApp, getApp, getApps } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 
 const firebaseConfig = {
@@ -11,6 +11,6 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
-const app = initializeApp(firebaseConfig);
+const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 export const auth = getAuth(app);
 


### PR DESCRIPTION
## Summary
- avoid duplicate initialization in firebase client
- ensure analytics helper uses existing Firebase app

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684d75bf7004832f9037e4f2ee8f1949