### PR TITLE
Enable Firebase auth with role selection

### DIFF
--- a/components/ChooseRoleModal.js
+++ b/components/ChooseRoleModal.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
+import { useAuth } from '../lib/AuthContext';
 
 export default function ChooseRoleModal({ onClose }) {
+  const { updateRole } = useAuth();
   const [selected, setSelected] = useState(null);
 
   const roles = [
@@ -66,8 +68,9 @@ export default function ChooseRoleModal({ onClose }) {
     }
   };
 
-  const handleContinue = () => {
-    console.log(selected);
+  const handleContinue = async () => {
+    if (!selected) return;
+    await updateRole(selected);
     onClose && onClose(selected);
   };
 

--- a/components/LoginModal.js
+++ b/components/LoginModal.js
@@ -1,9 +1,33 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useAuth } from '../lib/AuthContext';
 
 export default function LoginModal({ onClose, onForgot, onSignup }) {
+  const { signIn, signInWithGoogle } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
   const handleBackdrop = (e) => {
     if (e.target === e.currentTarget) {
       onClose();
+    }
+  };
+
+  const handleSubmit = async () => {
+    try {
+      await signIn(email, password);
+      onClose && onClose();
+    } catch (err) {
+      setError('Invalid credentials');
+    }
+  };
+
+  const handleGoogle = async () => {
+    try {
+      await signInWithGoogle();
+      onClose && onClose();
+    } catch (err) {
+      setError('Google sign in failed');
     }
   };
 
@@ -18,14 +42,24 @@ export default function LoginModal({ onClose, onForgot, onSignup }) {
         <input
           type="email"
           placeholder="Email address"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
           className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-gray-800 w-full mt-4"
         />
         <input
           type="password"
           placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
           className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-gray-800 w-full mt-4"
         />
-        <button className="w-full rounded-xl bg-[#6c63ff] text-white font-semibold py-3 mt-6 hover:bg-[#5b54d6]">
+        {error && (
+          <p className="text-red-600 text-sm text-center mt-2">{error}</p>
+        )}
+        <button
+          onClick={handleSubmit}
+          className="w-full rounded-xl bg-[#6c63ff] text-white font-semibold py-3 mt-6 hover:bg-[#5b54d6]"
+        >
           Sign In
         </button>
         <div className="flex items-center gap-4 text-gray-400 text-sm mt-6 mb-4">
@@ -33,7 +67,10 @@ export default function LoginModal({ onClose, onForgot, onSignup }) {
           OR
           <hr className="flex-grow border-gray-300" />
         </div>
-        <button className="border border-gray-300 rounded-xl py-3 px-4 w-full flex items-center justify-center gap-3 font-semibold bg-white">
+        <button
+          onClick={handleGoogle}
+          className="border border-gray-300 rounded-xl py-3 px-4 w-full flex items-center justify-center gap-3 font-semibold bg-white"
+        >
           <span className="text-xl">G</span>
           Continue with Google
         </button>

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,11 +1,19 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import LoginModal from './LoginModal';
 import ResetPasswordModal from './ResetPasswordModal';
 import SignupModal from './SignupModal';
 import ChooseRoleModal from './ChooseRoleModal';
+import { useAuth } from '../lib/AuthContext';
 
 export default function Navbar() {
+  const { user, signOut, loading } = useAuth();
   const [modal, setModal] = useState(null); // 'login' | 'reset' | 'signup' | 'role'
+
+  useEffect(() => {
+    if (!loading && user && !user.role) {
+      setModal('role');
+    }
+  }, [user, loading]);
 
   return (
     <>
@@ -38,22 +46,41 @@ export default function Navbar() {
             FAQ
           </a>
           <div className="flex items-center gap-2">
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                setModal('login');
-              }}
-              className="border border-[#6466f1] text-[#6466f1] rounded-md px-4 py-2 text-sm font-bold hover:bg-[#6466f1]/20 transition"
-            >
-              Login
-            </a>
-            <button
-              onClick={() => setModal('role')}
-              className="bg-[#6466f1] text-white rounded-md px-4 py-2 text-sm font-bold transition-transform duration-300 transform hover:scale-105 hover:animate-bounce"
-            >
-              Get Started
-            </button>
+            {user ? (
+              <>
+                <button
+                  onClick={signOut}
+                  className="border border-[#6466f1] text-[#6466f1] rounded-md px-4 py-2 text-sm font-bold hover:bg-[#6466f1]/20 transition"
+                >
+                  Sign Out
+                </button>
+                <button
+                  onClick={() => setModal('role')}
+                  className="bg-[#6466f1] text-white rounded-md px-4 py-2 text-sm font-bold transition-transform duration-300 transform hover:scale-105 hover:animate-bounce"
+                >
+                  {user.role ? 'Dashboard' : 'Choose Role'}
+                </button>
+              </>
+            ) : (
+              <>
+                <a
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setModal('login');
+                  }}
+                  className="border border-[#6466f1] text-[#6466f1] rounded-md px-4 py-2 text-sm font-bold hover:bg-[#6466f1]/20 transition"
+                >
+                  Login
+                </a>
+                <button
+                  onClick={() => setModal('signup')}
+                  className="bg-[#6466f1] text-white rounded-md px-4 py-2 text-sm font-bold transition-transform duration-300 transform hover:scale-105 hover:animate-bounce"
+                >
+                  Get Started
+                </button>
+              </>
+            )}
           </div>
         </div>
       </div>
@@ -75,6 +102,7 @@ export default function Navbar() {
       <SignupModal
         onClose={() => setModal(null)}
         onSignIn={() => setModal('login')}
+        onRegistered={() => setModal('role')}
       />
     )}
     {modal === 'role' && (

--- a/components/SignupModal.js
+++ b/components/SignupModal.js
@@ -1,11 +1,13 @@
 'use client';
 import React, { useState } from 'react';
+import { useAuth } from '../lib/AuthContext';
 
-export default function SignupModal({ onClose, onSignIn }) {
+export default function SignupModal({ onClose, onSignIn, onRegistered }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
   const [error, setError] = useState('');
+  const { signUp } = useAuth();
 
   const handleBackdrop = (e) => {
     if (e.target === e.currentTarget) {
@@ -13,14 +15,20 @@ export default function SignupModal({ onClose, onSignIn }) {
     }
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (password !== confirm) {
       setError('Passwords do not match');
       return;
     }
     setError('');
-    // handle signup logic here
+    try {
+      await signUp(email, password);
+      onClose && onClose();
+      onRegistered && onRegistered();
+    } catch (err) {
+      setError('Unable to create account');
+    }
   };
 
   return (

--- a/lib/AuthContext.js
+++ b/lib/AuthContext.js
@@ -1,0 +1,73 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import {
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+  GoogleAuthProvider,
+  signOut,
+  onAuthStateChanged,
+} from 'firebase/auth';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { auth, db } from './firebaseClient';
+
+const AuthContext = createContext({ user: null });
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, async (u) => {
+      if (u) {
+        const docRef = doc(db, 'users', u.uid);
+        const snap = await getDoc(docRef);
+        const role = snap.exists() ? snap.data().role : null;
+        setUser({ ...u, role });
+      } else {
+        setUser(null);
+      }
+      setLoading(false);
+    });
+    return unsub;
+  }, []);
+
+  const signUp = async (email, password) => {
+    const cred = await createUserWithEmailAndPassword(auth, email, password);
+    setUser({ ...cred.user, role: null });
+  };
+
+  const signIn = async (email, password) => {
+    const cred = await signInWithEmailAndPassword(auth, email, password);
+    const docRef = doc(db, 'users', cred.user.uid);
+    const snap = await getDoc(docRef);
+    const role = snap.exists() ? snap.data().role : null;
+    setUser({ ...cred.user, role });
+  };
+
+  const signInWithGoogle = async () => {
+    const provider = new GoogleAuthProvider();
+    const cred = await signInWithPopup(auth, provider);
+    const docRef = doc(db, 'users', cred.user.uid);
+    const snap = await getDoc(docRef);
+    const role = snap.exists() ? snap.data().role : null;
+    setUser({ ...cred.user, role });
+  };
+
+  const updateRole = async (role) => {
+    if (!user) return;
+    await setDoc(doc(db, 'users', user.uid), { role }, { merge: true });
+    setUser({ ...user, role });
+  };
+
+  const signOutUser = () => signOut(auth);
+
+  return (
+    <AuthContext.Provider
+      value={{ user, loading, signUp, signIn, signInWithGoogle, updateRole, signOut: signOutUser }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/lib/firebaseClient.js
+++ b/lib/firebaseClient.js
@@ -1,5 +1,6 @@
 import { initializeApp, getApp, getApps } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -13,4 +14,5 @@ const firebaseConfig = {
 
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 export const auth = getAuth(app);
+export const db = getFirestore(app);
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,10 @@
 import '../styles/globals.css';
+import { AuthProvider } from '../lib/AuthContext';
+
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  return (
+    <AuthProvider>
+      <Component {...pageProps} />
+    </AuthProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- add Firestore connection in `firebaseClient`
- implement authentication context with Firebase
- update login and signup modals to create/sign in users and support Google sign in
- persist chosen role to Firestore via `ChooseRoleModal`
- wrap app with new `AuthProvider`
- update navbar to react to auth state and show role modal when needed

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d7d60acf4832f8ae1d273c38dbadd