### PR TITLE
Use env vars for firebase analytics

### DIFF
--- a/lib/firebaseAnalytics.js
+++ b/lib/firebaseAnalytics.js
@@ -8,13 +8,13 @@ import { getAnalytics } from "firebase/analytics";
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
-  apiKey: "AIzaSyBFqNhXsxXlZXgBNHKtnZqgH_vQQZcIF8w",
-  authDomain: "flutterpub-web.firebaseapp.com",
-  projectId: "flutterpub-web",
-  storageBucket: "flutterpub-web.firebasestorage.app",
-  messagingSenderId: "675649620325",
-  appId: "1:675649620325:web:33d71240457b2c83aa398c",
-  measurementId: "G-Z0PKF6KX7Z"
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
 // Initialize Firebase if not already initialized


### PR DESCRIPTION
## Summary
- use environment variables for Firebase Analytics config

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d88dca088832f9db1a22790f69f98