### PR TITLE
Standardize project naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# FlutterPup Starter with Firebase
+# FlutterPup
 
-This is a starter repo for building your FlutterPup SaaS using Next.js,
-Tailwind CSS, and Firebase.
+Starter template for building a FlutterPup SaaS using Next.js,
+Tailwind CSS and Firebase.
 
 ## Local setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "flutterpup-frontend",
+  "name": "flutterpup",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "flutterpup-frontend",
+      "name": "flutterpup",
       "version": "1.0.0",
       "dependencies": {
         "@heroicons/react": "^2.0.18",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "flutterpup-frontend",
+  "name": "flutterpup",
   "version": "1.0.0",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- adopt `FlutterPup` as the official project name
- update README heading
- update package name in `package.json` and `package-lock.json`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8a1511d8832f8ba68106dd65d030