### PR TITLE
Add business dashboard page and navigation

### DIFF
--- a/components/ChooseRoleModal.js
+++ b/components/ChooseRoleModal.js
@@ -76,6 +76,8 @@ export default function ChooseRoleModal({ onClose }) {
     onClose && onClose(selected);
     if (selected === 'developer') {
       router.push('/developer/dashboard');
+    } else if (selected === 'businessman') {
+      router.push('/business/dashboard');
     }
   };
 

--- a/components/LoginModal.js
+++ b/components/LoginModal.js
@@ -21,6 +21,8 @@ export default function LoginModal({ onClose, onForgot, onSignup }) {
       onClose && onClose();
       if (u?.role === 'developer') {
         router.push('/developer/dashboard');
+      } else if (u?.role === 'businessman') {
+        router.push('/business/dashboard');
       }
     } catch (err) {
       setError('Invalid credentials');
@@ -33,6 +35,8 @@ export default function LoginModal({ onClose, onForgot, onSignup }) {
       onClose && onClose();
       if (u?.role === 'developer') {
         router.push('/developer/dashboard');
+      } else if (u?.role === 'businessman') {
+        router.push('/business/dashboard');
       }
     } catch (err) {
       setError('Google sign in failed');

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -15,8 +15,12 @@ export default function Navbar() {
     if (!loading && user && !user.role) {
       setModal('role');
     }
-    if (!loading && user?.role === 'developer' && router.pathname === '/') {
-      router.push('/developer/dashboard');
+    if (!loading && router.pathname === '/') {
+      if (user?.role === 'developer') {
+        router.push('/developer/dashboard');
+      } else if (user?.role === 'businessman') {
+        router.push('/business/dashboard');
+      }
     }
   }, [user, loading, router]);
 
@@ -61,7 +65,13 @@ export default function Navbar() {
                 </button>
                 {user.role ? (
                   <button
-                    onClick={() => router.push('/developer/dashboard')}
+                    onClick={() =>
+                      router.push(
+                        user.role === 'developer'
+                          ? '/developer/dashboard'
+                          : '/business/dashboard'
+                      )
+                    }
                     className="bg-[#6466f1] text-white rounded-md px-4 py-2 text-sm font-bold transition-transform duration-300 transform hover:scale-105 hover:animate-bounce"
                   >
                     Dashboard

--- a/pages/business/dashboard.js
+++ b/pages/business/dashboard.js
@@ -1,0 +1,31 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { useAuth } from '../../lib/AuthContext';
+
+export default function BusinessDashboard() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && (!user || user.role !== 'businessman')) {
+      router.replace('/');
+    }
+  }, [user, loading, router]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <h1 className="text-2xl font-bold mb-6">Business Dashboard</h1>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="bg-white rounded-lg shadow p-6">
+          <h2 className="text-xl font-semibold mb-2">Project Overview</h2>
+          <p className="text-gray-500">Your projects will be shown here.</p>
+        </div>
+        <div className="bg-white rounded-lg shadow p-6">
+          <h2 className="text-xl font-semibold mb-2">AI Tools</h2>
+          <p className="text-gray-500">AI powered planning and analytics tools will appear here.</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add business dashboard page with role gating
- support businessman role in Navbar and modals

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d91c3c700832f884a52a35312d707