### PR TITLE
Add sign-out to developer sidebar

### DIFF
--- a/pages/developer/dashboard.js
+++ b/pages/developer/dashboard.js
@@ -2,10 +2,16 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import Image from 'next/image';
 import { useAuth } from '../../lib/AuthContext';
-import { RocketLaunchIcon, TrophyIcon, BriefcaseIcon, ChatBubbleOvalLeftEllipsisIcon } from '@heroicons/react/24/solid';
+import {
+  RocketLaunchIcon,
+  TrophyIcon,
+  BriefcaseIcon,
+  ChatBubbleOvalLeftEllipsisIcon,
+  ArrowRightOnRectangleIcon,
+} from '@heroicons/react/24/solid';
 
 export default function DeveloperDashboard() {
-  const { user, loading } = useAuth();
+  const { user, loading, signOut } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
@@ -54,6 +60,13 @@ export default function DeveloperDashboard() {
           <button className="w-full border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2">
             <ChatBubbleOvalLeftEllipsisIcon className="w-5 h-5" />
             Contact Support
+          </button>
+          <button
+            onClick={signOut}
+            className="w-full mt-3 border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2"
+          >
+            <ArrowRightOnRectangleIcon className="w-5 h-5" />
+            Sign Out
           </button>
         </div>
       </aside>

--- a/pages/developer/level.js
+++ b/pages/developer/level.js
@@ -13,11 +13,12 @@ import {
   BoltIcon,
   BugAntIcon,
   UserGroupIcon,
+  ArrowRightOnRectangleIcon,
 } from '@heroicons/react/24/solid';
 import { useAuth } from '../../lib/AuthContext';
 
 export default function MyLevel() {
-  const { user, loading } = useAuth();
+  const { user, loading, signOut } = useAuth();
   const router = useRouter();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -99,6 +100,13 @@ export default function MyLevel() {
           <button className="w-full border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2">
             <ChatBubbleOvalLeftEllipsisIcon className="w-5 h-5" />
             Contact Support
+          </button>
+          <button
+            onClick={signOut}
+            className="w-full mt-3 border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2"
+          >
+            <ArrowRightOnRectangleIcon className="w-5 h-5" />
+            Sign Out
           </button>
         </div>
       </aside>

--- a/pages/developer/projects.js
+++ b/pages/developer/projects.js
@@ -11,11 +11,12 @@ import {
   CheckCircleIcon,
   BoltIcon,
   ArrowRightIcon,
+  ArrowRightOnRectangleIcon,
 } from '@heroicons/react/24/solid';
 import { useAuth } from '../../lib/AuthContext';
 
 export default function MatchedProjects() {
-  const { user, loading } = useAuth();
+  const { user, loading, signOut } = useAuth();
   const router = useRouter();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -95,6 +96,13 @@ export default function MatchedProjects() {
           <button className="w-full border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2">
             <ChatBubbleOvalLeftEllipsisIcon className="w-5 h-5" />
             Contact Support
+          </button>
+          <button
+            onClick={signOut}
+            className="w-full mt-3 border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2"
+          >
+            <ArrowRightOnRectangleIcon className="w-5 h-5" />
+            Sign Out
           </button>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- show a Sign Out button in developer dashboard side menu
- include the option on all developer pages

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d934f30e8832fbe14da5dcf582a5d