### PR TITLE
Fix business dashboard nav

### DIFF
--- a/pages/business/dashboard.jsx
+++ b/pages/business/dashboard.jsx
@@ -28,9 +28,10 @@ export default function BusinessDashboard() {
     }
   }, [user, loading, router]);
 
-  const NavItem = ({ active, Icon, children }) => (
+  const NavItem = ({ active, Icon, children, ...props }) => (
     <button
       className={`flex items-center gap-3 w-full px-4 py-2 rounded-md hover:bg-white/10 ${active ? 'bg-white/20 font-semibold' : ''}`}
+      {...props}
     >
       <Icon className="w-5 h-5" />
       {children}
@@ -105,8 +106,19 @@ export default function BusinessDashboard() {
             </button>
           </div>
           <nav className="mt-6 px-4 space-y-1">
-            <NavItem active Icon={HomeIcon}>Overview</NavItem>
-            <NavItem Icon={FolderIcon}>Projects</NavItem>
+            <NavItem
+              active
+              Icon={HomeIcon}
+              onClick={() => router.push('/business/dashboard')}
+            >
+              Overview
+            </NavItem>
+            <NavItem
+              Icon={FolderIcon}
+              onClick={() => router.push('/business/projects')}
+            >
+              Projects
+            </NavItem>
             <NavItem Icon={CpuChipIcon}>AI Doers</NavItem>
             <NavItem Icon={UserGroupIcon}>Developers</NavItem>
             <NavItem Icon={Cog6ToothIcon}>Settings</NavItem>

--- a/pages/business/projects.tsx
+++ b/pages/business/projects.tsx
@@ -125,11 +125,12 @@ export default function Projects() {
     return matchesTab && matchesQuery;
   });
 
-  const NavItem = ({ active, Icon, children }: any) => (
+  const NavItem = ({ active, Icon, children, ...props }: any) => (
     <button
       className={`flex items-center gap-3 w-full px-4 py-2 rounded-md hover:bg-white/10 ${
         active ? 'bg-white/20 font-semibold' : ''
       }`}
+      {...props}
     >
       <Icon className="w-5 h-5" />
       {children}
@@ -178,8 +179,19 @@ export default function Projects() {
             </button>
           </div>
           <nav className="mt-6 px-4 space-y-1">
-            <NavItem Icon={HomeIcon}>Overview</NavItem>
-            <NavItem active Icon={FolderIcon}>Projects</NavItem>
+            <NavItem
+              Icon={HomeIcon}
+              onClick={() => router.push('/business/dashboard')}
+            >
+              Overview
+            </NavItem>
+            <NavItem
+              active
+              Icon={FolderIcon}
+              onClick={() => router.push('/business/projects')}
+            >
+              Projects
+            </NavItem>
             <NavItem Icon={CpuChipIcon}>AI Doers</NavItem>
             <NavItem Icon={UserGroupIcon}>Developers</NavItem>
             <NavItem Icon={Cog6ToothIcon}>Settings</NavItem>


### PR DESCRIPTION
## Summary
- allow passing props to business dashboard nav items
- push the projects page when clicking Projects nav item
- match nav behaviour on the projects page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d9e87b0b8832f807db959fd9129e7