### PR TITLE
Add statistic cards component for Business Dashboard

### DIFF
--- a/components/StatsCards.tsx
+++ b/components/StatsCards.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {
+  FolderIcon,
+  PlayCircleIcon,
+  CheckCircleIcon,
+  CurrencyDollarIcon,
+} from '@heroicons/react/24/outline';
+
+interface Stat {
+  label: string;
+  value: string;
+  icon: (props: React.SVGProps<SVGSVGElement>) => JSX.Element;
+  bg: string;
+  color: string;
+  tooltip?: string;
+}
+
+const stats: Stat[] = [
+  {
+    label: 'Total Projects',
+    value: '2',
+    icon: FolderIcon,
+    bg: 'bg-blue-100',
+    color: 'text-blue-500',
+    tooltip: 'Includes archived projects',
+  },
+  {
+    label: 'Active Projects',
+    value: '1',
+    icon: PlayCircleIcon,
+    bg: 'bg-green-100',
+    color: 'text-green-500',
+    tooltip: 'Projects currently in progress',
+  },
+  {
+    label: 'Completed Projects',
+    value: '0',
+    icon: CheckCircleIcon,
+    bg: 'bg-emerald-100',
+    color: 'text-emerald-500',
+    tooltip: 'Projects marked as done',
+  },
+  {
+    label: 'Total Spent',
+    value: '$1250',
+    icon: CurrencyDollarIcon,
+    bg: 'bg-red-100',
+    color: 'text-red-500',
+    tooltip: 'Total budget used',
+  },
+];
+
+const StatCard = ({ icon: Icon, bg, color, value, label, tooltip }: Stat) => (
+  <div
+    className="bg-white rounded-xl shadow-md p-5 flex items-start gap-4 hover:scale-105 transition-transform duration-200"
+    title={tooltip}
+  >
+    <div className={`rounded-lg p-3 bg-opacity-50 ${bg}`}>
+      <Icon className={`w-6 h-6 ${color}`} />
+    </div>
+    <div>
+      <p className="text-2xl font-bold text-gray-800">{value}</p>
+      <p className="text-sm text-gray-500">{label}</p>
+    </div>
+  </div>
+);
+
+export default function StatsCards() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
+      {stats.map((stat) => (
+        <StatCard key={stat.label} {...stat} />
+      ))}
+    </div>
+  );
+}
+

--- a/pages/business/dashboard.jsx
+++ b/pages/business/dashboard.jsx
@@ -17,6 +17,7 @@ import {
   CalendarDaysIcon,
   ArrowRightOnRectangleIcon,
 } from '@heroicons/react/24/outline';
+import StatsCards from '../../components/StatsCards';
 
 export default function BusinessDashboard() {
   const { user, loading, signOut } = useAuth();
@@ -39,12 +40,6 @@ export default function BusinessDashboard() {
     </button>
   );
 
-  const StatCard = ({ label, value }) => (
-    <div className="bg-white rounded-xl shadow-md p-5">
-      <p className="text-sm text-gray-500">{label}</p>
-      <p className="text-2xl font-bold mt-1">{value}</p>
-    </div>
-  );
 
   const RecentProjectItem = ({ title, template, status, date }) => (
     <div className="flex items-center justify-between py-3 first:pt-0 last:pb-0">
@@ -160,11 +155,8 @@ export default function BusinessDashboard() {
         </header>
         <main className="flex-1 p-6 space-y-6 bg-gray-50 overflow-y-auto">
           {/* Stats summary */}
-          <section className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-            <StatCard label="Total Projects" value="2" />
-            <StatCard label="Active Projects" value="1" />
-            <StatCard label="Completed Projects" value="0" />
-            <StatCard label="Total Spent" value="$1250" />
+          <section>
+            <StatsCards />
           </section>
 
           {/* Recent projects */}


### PR DESCRIPTION
## Summary
- create reusable `StatsCards` component with Heroicons
- show new stats cards on the Business dashboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da5024b78832fb307c5b0f9b51443