### PR TITLE
Add reusable developer sidebar

### DIFF
--- a/components/DeveloperSidebar.js
+++ b/components/DeveloperSidebar.js
@@ -1,0 +1,87 @@
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import Image from 'next/image';
+import {
+  RocketLaunchIcon,
+  TrophyIcon,
+  BriefcaseIcon,
+  ChatBubbleOvalLeftEllipsisIcon,
+  ArrowRightOnRectangleIcon,
+  Bars3Icon,
+  XMarkIcon,
+} from '@heroicons/react/24/solid';
+import { useAuth } from '../lib/AuthContext';
+
+export default function DeveloperSidebar({ active }) {
+  const { signOut } = useAuth();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+
+  const NavButton = ({ page, Icon, children }) => (
+    <button
+      className={`flex items-center gap-3 w-full px-3 py-2 rounded-md hover:bg-white/10 ${
+        active === page ? 'bg-white/10 font-semibold border-l-4 border-white' : ''
+      }`}
+      onClick={() => {
+        router.push(`/developer/${page}`);
+        setOpen(false);
+      }}
+    >
+      <Icon className="w-5 h-5" />
+      {children}
+    </button>
+  );
+
+  return (
+    <>
+      <button className="sm:hidden p-2 text-gray-700" onClick={() => setOpen(true)}>
+        <Bars3Icon className="w-6 h-6" />
+      </button>
+      <aside
+        className={`fixed inset-y-0 left-0 z-40 w-[280px] shrink-0 bg-[#7064F0] text-white flex flex-col justify-between transform transition-transform duration-200 ${
+          open ? 'translate-x-0' : '-translate-x-full'
+        } sm:translate-x-0 sm:static`}
+      >
+        <div>
+          <div className="flex justify-end sm:hidden p-2">
+            <button onClick={() => setOpen(false)}>
+              <XMarkIcon className="w-6 h-6" />
+            </button>
+          </div>
+          <div className="flex flex-col items-center py-6">
+            <div className="w-20 h-20 rounded-full border-4 border-white overflow-hidden mb-3">
+              <Image src="/images/hero.avif" alt="Profile" width={80} height={80} className="object-cover" />
+            </div>
+            <div className="font-bold">John Developer</div>
+            <div className="text-sm opacity-80">Level 1</div>
+          </div>
+          <nav className="mt-6 px-4 space-y-1">
+            <NavButton page="dashboard" Icon={RocketLaunchIcon}>
+              Missions
+            </NavButton>
+            <NavButton page="level" Icon={TrophyIcon}>
+              My Level
+            </NavButton>
+            <NavButton page="projects" Icon={BriefcaseIcon}>
+              Matched Projects
+            </NavButton>
+          </nav>
+        </div>
+        <div className="p-4 text-center">
+          <p className="text-sm mb-2">Need help with Flutter?</p>
+          <button className="w-full border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2">
+            <ChatBubbleOvalLeftEllipsisIcon className="w-5 h-5" />
+            Contact Support
+          </button>
+          <button
+            onClick={signOut}
+            className="w-full mt-3 border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2"
+          >
+            <ArrowRightOnRectangleIcon className="w-5 h-5" />
+            Sign Out
+          </button>
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/pages/developer/dashboard.js
+++ b/pages/developer/dashboard.js
@@ -2,16 +2,10 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import Image from 'next/image';
 import { useAuth } from '../../lib/AuthContext';
-import {
-  RocketLaunchIcon,
-  TrophyIcon,
-  BriefcaseIcon,
-  ChatBubbleOvalLeftEllipsisIcon,
-  ArrowRightOnRectangleIcon,
-} from '@heroicons/react/24/solid';
+import DeveloperSidebar from '../../components/DeveloperSidebar';
 
 export default function DeveloperDashboard() {
-  const { user, loading, signOut } = useAuth();
+  const { user, loading } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
@@ -22,54 +16,7 @@ export default function DeveloperDashboard() {
 
   return (
     <div className="flex h-screen font-sans">
-      <aside className="w-[280px] shrink-0 bg-[#7064F0] text-white flex flex-col justify-between">
-        <div>
-          <div className="flex flex-col items-center py-6">
-            <div className="w-20 h-20 rounded-full border-4 border-white overflow-hidden mb-3">
-              <Image src="/images/hero.avif" alt="Profile" width={80} height={80} className="object-cover" />
-            </div>
-            <div className="font-bold">John Developer</div>
-            <div className="text-sm opacity-80">Level 1</div>
-          </div>
-          <nav className="mt-6 px-4 space-y-1">
-            <button
-              className="flex items-center gap-3 w-full bg-white/10 rounded-md px-3 py-2 font-semibold"
-              onClick={() => router.push('/developer/dashboard')}
-            >
-              <RocketLaunchIcon className="w-5 h-5" />
-              Missions
-            </button>
-            <button
-              className="flex items-center gap-3 w-full hover:bg-white/10 rounded-md px-3 py-2"
-              onClick={() => router.push('/developer/level')}
-            >
-              <TrophyIcon className="w-5 h-5" />
-              My Level
-            </button>
-            <button
-              className="flex items-center gap-3 w-full hover:bg-white/10 rounded-md px-3 py-2"
-              onClick={() => router.push('/developer/projects')}
-            >
-              <BriefcaseIcon className="w-5 h-5" />
-              Matched Projects
-            </button>
-          </nav>
-        </div>
-        <div className="p-4 text-center">
-          <p className="text-sm mb-2">Need help with Flutter?</p>
-          <button className="w-full border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2">
-            <ChatBubbleOvalLeftEllipsisIcon className="w-5 h-5" />
-            Contact Support
-          </button>
-          <button
-            onClick={signOut}
-            className="w-full mt-3 border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2"
-          >
-            <ArrowRightOnRectangleIcon className="w-5 h-5" />
-            Sign Out
-          </button>
-        </div>
-      </aside>
+      <DeveloperSidebar active="dashboard" />
       <main className="flex-1 overflow-y-auto p-6 bg-gray-50">
         <h1 className="text-2xl font-bold mb-4">Learning Missions</h1>
         <div className="flex gap-3 mb-6">

--- a/pages/developer/level.js
+++ b/pages/developer/level.js
@@ -1,42 +1,27 @@
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import Image from 'next/image';
 import {
-  RocketLaunchIcon,
-  TrophyIcon,
-  BriefcaseIcon,
-  ChatBubbleOvalLeftEllipsisIcon,
-  Bars3Icon,
-  XMarkIcon,
   ShareIcon,
   CodeBracketIcon,
   BoltIcon,
   BugAntIcon,
+  RocketLaunchIcon,
+  TrophyIcon,
   UserGroupIcon,
-  ArrowRightOnRectangleIcon,
 } from '@heroicons/react/24/solid';
+import DeveloperSidebar from '../../components/DeveloperSidebar';
 import { useAuth } from '../../lib/AuthContext';
 
 export default function MyLevel() {
-  const { user, loading, signOut } = useAuth();
+  const { user, loading } = useAuth();
   const router = useRouter();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   useEffect(() => {
     if (!loading && (!user || user.role !== 'developer')) {
       router.replace('/');
     }
   }, [user, loading, router]);
-
-  const NavItem = ({ active, Icon, children, ...props }) => (
-    <button
-      className={`flex items-center gap-3 w-full px-3 py-2 rounded-md hover:bg-white/10 ${active ? 'bg-white/10 font-semibold border-l-4 border-white' : ''}`}
-      {...props}
-    >
-      <Icon className="w-5 h-5" />
-      {children}
-    </button>
-  );
 
   const Badge = ({ color, Icon, label }) => (
     <div className="flex flex-col items-center text-sm font-semibold mr-4 mb-4">
@@ -49,67 +34,7 @@ export default function MyLevel() {
 
   return (
     <div className="flex h-screen font-sans">
-      {/* Mobile hamburger */}
-      <button
-        className="sm:hidden p-2 text-gray-700"
-        onClick={() => setSidebarOpen(true)}
-      >
-        <Bars3Icon className="w-6 h-6" />
-      </button>
-      {/* Sidebar */}
-      <aside
-        className={`fixed inset-y-0 left-0 z-40 w-[280px] shrink-0 bg-[#7064F0] text-white flex flex-col justify-between transform transition-transform duration-200 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'} sm:translate-x-0 sm:static`}
-      >
-        <div>
-          <div className="flex justify-end sm:hidden p-2">
-            <button onClick={() => setSidebarOpen(false)}>
-              <XMarkIcon className="w-6 h-6" />
-            </button>
-          </div>
-          <div className="flex flex-col items-center py-6">
-            <div className="w-20 h-20 rounded-full border-4 border-white overflow-hidden mb-3">
-              <Image src="/images/hero.avif" alt="Profile" width={80} height={80} className="object-cover" />
-            </div>
-            <div className="font-bold">John Developer</div>
-            <div className="text-sm opacity-80">Level 1</div>
-          </div>
-          <nav className="mt-6 px-4 space-y-1">
-            <NavItem
-              Icon={RocketLaunchIcon}
-              onClick={() => router.push('/developer/dashboard')}
-            >
-              Missions
-            </NavItem>
-            <NavItem
-              active
-              Icon={TrophyIcon}
-              onClick={() => router.push('/developer/level')}
-            >
-              My Level
-            </NavItem>
-            <NavItem
-              Icon={BriefcaseIcon}
-              onClick={() => router.push('/developer/projects')}
-            >
-              Matched Projects
-            </NavItem>
-          </nav>
-        </div>
-        <div className="p-4 text-center">
-          <p className="text-sm mb-2">Need help with Flutter?</p>
-          <button className="w-full border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2">
-            <ChatBubbleOvalLeftEllipsisIcon className="w-5 h-5" />
-            Contact Support
-          </button>
-          <button
-            onClick={signOut}
-            className="w-full mt-3 border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2"
-          >
-            <ArrowRightOnRectangleIcon className="w-5 h-5" />
-            Sign Out
-          </button>
-        </div>
-      </aside>
+      <DeveloperSidebar active="level" />
 
       {/* Main content */}
       <main className="flex-1 overflow-y-auto p-6 bg-gray-50">

--- a/pages/developer/projects.js
+++ b/pages/developer/projects.js
@@ -1,42 +1,23 @@
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import Image from 'next/image';
 import {
-  RocketLaunchIcon,
-  TrophyIcon,
-  BriefcaseIcon,
-  ChatBubbleOvalLeftEllipsisIcon,
-  Bars3Icon,
-  XMarkIcon,
   CheckCircleIcon,
   BoltIcon,
   ArrowRightIcon,
-  ArrowRightOnRectangleIcon,
 } from '@heroicons/react/24/solid';
 import { useAuth } from '../../lib/AuthContext';
+import DeveloperSidebar from '../../components/DeveloperSidebar';
 
 export default function MatchedProjects() {
-  const { user, loading, signOut } = useAuth();
+  const { user, loading } = useAuth();
   const router = useRouter();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   useEffect(() => {
     if (!loading && (!user || user.role !== 'developer')) {
       router.replace('/');
     }
   }, [user, loading, router]);
-
-  const NavItem = ({ active, Icon, children, ...props }) => (
-    <button
-      className={`flex items-center gap-3 w-full px-3 py-2 rounded-md hover:bg-white/10 ${
-        active ? 'bg-[#3F51F5] font-semibold border-l-4 border-white' : ''
-      }`}
-      {...props}
-    >
-      <Icon className="w-5 h-5" />
-      {children}
-    </button>
-  );
 
   const FilterButton = ({ active, children, ...props }) => (
     <button
@@ -59,53 +40,7 @@ export default function MatchedProjects() {
 
   return (
     <div className="flex h-screen font-sans">
-      {/* Mobile hamburger */}
-      <button
-        className="sm:hidden p-2 text-gray-700"
-        onClick={() => setSidebarOpen(true)}
-      >
-        <Bars3Icon className="w-6 h-6" />
-      </button>
-      {/* Sidebar */}
-      <aside
-        className={`fixed inset-y-0 left-0 z-40 w-[280px] shrink-0 bg-[#7064F0] text-white flex flex-col justify-between transform transition-transform duration-200 ${
-          sidebarOpen ? 'translate-x-0' : '-translate-x-full'
-        } sm:translate-x-0 sm:static`}
-      >
-        <div>
-          <div className="flex justify-end sm:hidden p-2">
-            <button onClick={() => setSidebarOpen(false)}>
-              <XMarkIcon className="w-6 h-6" />
-            </button>
-          </div>
-          <div className="flex flex-col items-center py-6">
-            <div className="w-20 h-20 rounded-full border-4 border-white overflow-hidden mb-3">
-              <Image src="/images/hero.avif" alt="Profile" width={80} height={80} className="object-cover" />
-            </div>
-            <div className="font-bold">John Developer</div>
-            <div className="text-sm text-violet-300">Level 1</div>
-          </div>
-          <nav className="mt-6 px-4 space-y-1">
-            <NavItem Icon={RocketLaunchIcon} onClick={() => router.push('/developer/dashboard')}>Missions</NavItem>
-            <NavItem Icon={TrophyIcon} onClick={() => router.push('/developer/level')}>My Level</NavItem>
-            <NavItem active Icon={BriefcaseIcon} onClick={() => router.push('/developer/projects')}>Matched Projects</NavItem>
-          </nav>
-        </div>
-        <div className="p-4 text-center">
-          <p className="text-sm mb-2">Need help with Flutter?</p>
-          <button className="w-full border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2">
-            <ChatBubbleOvalLeftEllipsisIcon className="w-5 h-5" />
-            Contact Support
-          </button>
-          <button
-            onClick={signOut}
-            className="w-full mt-3 border border-white rounded-full px-4 py-2 flex items-center justify-center gap-2"
-          >
-            <ArrowRightOnRectangleIcon className="w-5 h-5" />
-            Sign Out
-          </button>
-        </div>
-      </aside>
+      <DeveloperSidebar active="projects" />
       {/* Main content */}
       <main className="flex-1 overflow-y-auto p-6 bg-gray-50">
         <div className="flex items-center justify-between mb-6">


### PR DESCRIPTION
## Summary
- create `DeveloperSidebar` component with navigation and sign-out
- use `DeveloperSidebar` in dashboard, level and projects pages

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da7eaba08832fa309bedaef945679