### PR TITLE
Initialize AuthContext with no-op auth functions

### DIFF
--- a/lib/AuthContext.js
+++ b/lib/AuthContext.js
@@ -10,7 +10,16 @@ import {
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { auth, db } from './firebaseClient';
 
-const AuthContext = createContext({ user: null });
+const noop = async () => {};
+const AuthContext = createContext({
+  user: null,
+  loading: false,
+  signUp: noop,
+  signIn: noop,
+  signInWithGoogle: noop,
+  updateRole: noop,
+  signOut: noop,
+});
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);


### PR DESCRIPTION
## Summary
- prevent runtime errors when `useAuth` is called outside `AuthProvider`
- initialize `AuthContext` with dummy auth methods

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da93b1b1c832fa38532557be0a39e